### PR TITLE
Revert to CentOS 7 with yum update for Let's Encrypt fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM centos:8
+FROM centos:7
 
 # epel for cabextract
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8 \
+RUN yum update -y \
+    && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 \
+    && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 \
     && yum install -y --setopt=tsflags=nodocs \
     java-1.8.0-openjdk \
     #
@@ -32,12 +34,16 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     && yum clean all \
     && rm -rf /var/cache/yum
 
+RUN yum install -y https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
 ENV LIBREOFFICE_VERSION=6.2.8.2
 ENV LIBREOFFICE_MIRROR=https://downloadarchive.documentfoundation.org/libreoffice/old/
 
 RUN echo "Downloading LibreOffice ${LIBREOFFICE_VERSION}..." \
     && echo ${LIBREOFFICE_MIRROR}${LIBREOFFICE_VERSION}/rpm/x86_64/LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_rpm.tar.gz \
-    && wget --quiet ${LIBREOFFICE_MIRROR}${LIBREOFFICE_VERSION}/rpm/x86_64/LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_rpm.tar.gz \
+    && wget ${LIBREOFFICE_MIRROR}${LIBREOFFICE_VERSION}/rpm/x86_64/LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_rpm.tar.gz \
     && tar -xf LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_rpm.tar.gz \
     && cd LibreOffice_*_Linux_x86-64_rpm/RPMS \
     && (rm -f *integ* || true) \
@@ -49,10 +55,6 @@ RUN echo "Downloading LibreOffice ${LIBREOFFICE_VERSION}..." \
     && rm -rf LibreOffice_*_Linux_x86-64_rpm \
     && rm -f LibreOffice_*_Linux_x86-64_rpm.tar.gz \
     && ln -s /opt/libreoffice* /opt/libreoffice
-
-RUN yum install -y https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm \
-    && yum clean all \
-    && rm -rf /var/cache/yum
 
 # mscorefonts2 does not currently install cambria.ttc
 RUN echo "Downloading Cambria font collection..." \


### PR DESCRIPTION
This is intended to fix installation issues caused by the recent expiration of the Let's Encrypt Root CA.

Rather than upgrade to CentOS 8, which is going EOL soon, this keeps the image on CentOS 7.

This also removes the `--quiet` option from the LibreOffice `wget`. This is entirely a personal preference so progress can be watched during the long download process.

Resolves #3 